### PR TITLE
Don't hide external symbols in static library on non-windows

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -96,10 +96,10 @@ typedef void CURL;
  * libcurl external API function linkage decorations.
  */
 
-#ifdef CURL_STATICLIB
-#  define CURL_EXTERN
-#elif defined(WIN32) || defined(_WIN32) || defined(__SYMBIAN32__)
-#  if defined(BUILDING_LIBCURL)
+#if defined(WIN32) || defined(_WIN32) || defined(__SYMBIAN32__)
+#  if defined(CURL_STATICLIB)
+#    define CURL_EXTERN
+#  elif defined(BUILDING_LIBCURL)
 #    define CURL_EXTERN  __declspec(dllexport)
 #  else
 #    define CURL_EXTERN  __declspec(dllimport)


### PR DESCRIPTION
Fix `hidden symbol 'curl_easy_init' in libcurl.a(libcurl_la-easy.o) is referenced by DSO` when linking editor on linux