### PR TITLE
workaround for UWP WACK failure with GetTickCount

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "curl_setup.h": "c"
+    }
+}

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -32,12 +32,15 @@ extern bool Curl_isVistaOrGreater;
 struct curltime Curl_now(void)
 {
   struct curltime now;
+#ifndef CURL_WINDOWS_APP
   if(Curl_isVistaOrGreater) { /* QPC timer might have issues pre-Vista */
+#endif
     LARGE_INTEGER count;
     QueryPerformanceCounter(&count);
     now.tv_sec = (time_t)(count.QuadPart / Curl_freq.QuadPart);
     now.tv_usec = (int)((count.QuadPart % Curl_freq.QuadPart) * 1000000 /
                         Curl_freq.QuadPart);
+#ifndef CURL_WINDOWS_APP
   }
   else {
     /* Disable /analyze warning that GetTickCount64 is preferred  */
@@ -53,6 +56,7 @@ struct curltime Curl_now(void)
     now.tv_sec = milliseconds / 1000;
     now.tv_usec = (milliseconds % 1000) * 1000;
   }
+#endif
   return now;
 }
 

--- a/src/tool_util.c
+++ b/src/tool_util.c
@@ -35,12 +35,15 @@ extern bool tool_isVistaOrGreater;
 struct timeval tvnow(void)
 {
   struct timeval now;
+#ifndef CURL_WINDOWS_APP
   if(tool_isVistaOrGreater) { /* QPC timer might have issues pre-Vista */
+#endif
     LARGE_INTEGER count;
     QueryPerformanceCounter(&count);
     now.tv_sec = (long)(count.QuadPart / tool_freq.QuadPart);
     now.tv_usec = (long)((count.QuadPart % tool_freq.QuadPart) * 1000000 /
                          tool_freq.QuadPart);
+#ifndef CURL_WINDOWS_APP
   }
   else {
     /* Disable /analyze warning that GetTickCount64 is preferred  */
@@ -56,6 +59,7 @@ struct timeval tvnow(void)
     now.tv_sec = (long)(milliseconds / 1000);
     now.tv_usec = (long)((milliseconds % 1000) * 1000);
   }
+#endif
   return now;
 }
 


### PR DESCRIPTION
`#ifndef CURL_WINDOWS_APP` to avoid compiling in the GetTickCount code path which can only be it if `Curl_isVistaOrGreater` is false anyways.