### PR TITLE
[android] case 1382113 fix connection reuse

### DIFF
--- a/lib/config-android-arm32.h
+++ b/lib/config-android-arm32.h
@@ -247,6 +247,8 @@
 /* Define to 1 if you have the gethostname function. */
 #define HAVE_GETHOSTNAME 1
 
+#define HAVE_GETPEERNAME 1
+
 /* Define to 1 if you have a working getifaddrs function. */
 /* #undef HAVE_GETIFADDRS */
 

--- a/lib/config-android-arm64.h
+++ b/lib/config-android-arm64.h
@@ -247,6 +247,8 @@
 /* Define to 1 if you have the gethostname function. */
 #define HAVE_GETHOSTNAME 1
 
+#define HAVE_GETPEERNAME 1
+
 /* Define to 1 if you have a working getifaddrs function. */
 /* #undef HAVE_GETIFADDRS */
 

--- a/lib/config-android-x86.h
+++ b/lib/config-android-x86.h
@@ -247,6 +247,8 @@
 /* Define to 1 if you have the gethostname function. */
 #define HAVE_GETHOSTNAME 1
 
+#define HAVE_GETPEERNAME 1
+
 /* Define to 1 if you have a working getifaddrs function. */
 /* #undef HAVE_GETIFADDRS */
 

--- a/lib/config-android-x86_64.h
+++ b/lib/config-android-x86_64.h
@@ -247,6 +247,8 @@
 /* Define to 1 if you have the gethostname function. */
 #define HAVE_GETHOSTNAME 1
 
+#define HAVE_GETPEERNAME 1
+
 /* Define to 1 if you have a working getifaddrs function. */
 /* #undef HAVE_GETIFADDRS */
 


### PR DESCRIPTION
Function getpeername is required for curl to be able to reuse connections.
It is available on android, just the relevant define is missing.