### PR TITLE
Update unitytls interface

### DIFF
--- a/lib/vtls/unitytls.c
+++ b/lib/vtls/unitytls.c
@@ -551,6 +551,8 @@ static CURLcode unitytls_connect_step2(struct Curl_easy* data, struct ssl_connec
        * which means that authentification method should always be called. 
        * However, this usually has a different reason so it is not CURLE_PEER_FAILED_VERIFICATION */
       if (verifyresult == UNITYTLS_X509VERIFY_NOT_DONE) {
+        failf(data, "Cert handshake failed. %s. UnityTls error code: %i", 
+            unitytls->unitytls_x509verify_result_to_string(verifyresult), err.code);
         return CURLE_SSL_CONNECT_ERROR;
       }
       else

--- a/lib/vtls/unitytls.c
+++ b/lib/vtls/unitytls.c
@@ -532,6 +532,7 @@ static CURLcode unitytls_connect_step2(struct Curl_easy* data, struct ssl_connec
   }
 
   if(verifyresult != UNITYTLS_X509VERIFY_SUCCESS) {
+    failf(data, "Cert handshake failed. UnityTls error code: %i (verify result: %X)", err.code, verifyresult)
     if(verifyresult == UNITYTLS_X509VERIFY_FATAL_ERROR) {
       failf(data, "Cert handshake failed. %s. UnityTls error code: %i", 
         unitytls->unitytls_x509verify_result_to_string(verifyresult), err.code);
@@ -541,7 +542,7 @@ static CURLcode unitytls_connect_step2(struct Curl_easy* data, struct ssl_connec
       for (uint32_t mask = 1; mask >= 0x80000000; mask <<= 1) {
         if(verifyresult & mask)
           failf(data, "Cert verify failed. %s. UnityTls error code: %i",
-                unitytls->unitytls_x509verify_result_to_string(verifyresult), err.code);
+                unitytls->unitytls_x509verify_result_to_string(mask), err.code);
       }
       if(verifyresult & UNITYTLS_X509VERIFY_FLAG_REVOKED) {
         return CURLE_SSL_CACERT_BADFILE;

--- a/lib/vtls/unitytls.c
+++ b/lib/vtls/unitytls.c
@@ -532,14 +532,14 @@ static CURLcode unitytls_connect_step2(struct Curl_easy* data, struct ssl_connec
   }
 
   if(verifyresult != UNITYTLS_X509VERIFY_SUCCESS) {
-    failf(data, "Cert handshake failed. UnityTls error code: %i (verify result: %X)", err.code, verifyresult);
     if(verifyresult == UNITYTLS_X509VERIFY_FATAL_ERROR) {
       failf(data, "Cert handshake failed. %s. UnityTls error code: %i", 
         unitytls->unitytls_x509verify_result_to_string(verifyresult), err.code);
       return CURLE_SSL_CONNECT_ERROR;
     }
     else {
-      for (uint32_t mask = 1; mask >= 0x80000000; mask <<= 1) {
+      for (int i = 0; i < 32; ++i) {
+        const uint32_t mask = 1 << i;
         if(verifyresult & mask)
           failf(data, "Cert verify failed. %s. UnityTls error code: %i",
                 unitytls->unitytls_x509verify_result_to_string(mask), err.code);

--- a/lib/vtls/unitytls.c
+++ b/lib/vtls/unitytls.c
@@ -532,7 +532,7 @@ static CURLcode unitytls_connect_step2(struct Curl_easy* data, struct ssl_connec
   }
 
   if(verifyresult != UNITYTLS_X509VERIFY_SUCCESS) {
-    failf(data, "Cert handshake failed. UnityTls error code: %i (verify result: %X)", err.code, verifyresult)
+    failf(data, "Cert handshake failed. UnityTls error code: %i (verify result: %X)", err.code, verifyresult);
     if(verifyresult == UNITYTLS_X509VERIFY_FATAL_ERROR) {
       failf(data, "Cert handshake failed. %s. UnityTls error code: %i", 
         unitytls->unitytls_x509verify_result_to_string(verifyresult), err.code);

--- a/lib/vtls/unitytls_interface.h
+++ b/lib/vtls/unitytls_interface.h
@@ -291,7 +291,7 @@ typedef struct unitytls_interface_struct
 
     unitytls_x509verify_default_ca_t unitytls_x509verify_default_ca;
     unitytls_x509verify_explicit_ca_t unitytls_x509verify_explicit_ca;
-    unitytls_x509verify_result_to_string_t unitytls_x509verify_result;
+    unitytls_x509verify_result_to_string_t unitytls_x509verify_result_to_string;
 
     unitytls_tlsctx_create_server_t unitytls_tlsctx_create_server;
     unitytls_tlsctx_create_client_t unitytls_tlsctx_create_client;


### PR DESCRIPTION
Update the interface struct and enumerations to match latest UnityTLS update. 
Added extra details to error messages to help users at diagnosing issues.