### PR TITLE
Update unitytls interface

### DIFF
--- a/lib/vtls/unitytls.c
+++ b/lib/vtls/unitytls.c
@@ -551,6 +551,8 @@ static CURLcode unitytls_connect_step2(struct Curl_easy* data, struct ssl_connec
        * which means that authentification method should always be called. 
        * However, this usually has a different reason so it is not CURLE_PEER_FAILED_VERIFICATION */
       if (verifyresult == UNITYTLS_X509VERIFY_NOT_DONE) {
+        failf(data, "Cert handshake failed. %s. UnityTls error code: %i", 
+            unitytls->unitytls_x509verify_result_to_string(verifyresult), err.code);
         return CURLE_SSL_CONNECT_ERROR;
       }
       else

--- a/lib/vtls/unitytls.c
+++ b/lib/vtls/unitytls.c
@@ -532,6 +532,7 @@ static CURLcode unitytls_connect_step2(struct Curl_easy* data, struct ssl_connec
   }
 
   if(verifyresult != UNITYTLS_X509VERIFY_SUCCESS) {
+    failf(data, "Cert handshake failed. UnityTls error code: %i (verify result: %X)", err.code, verifyresult)
     if(verifyresult == UNITYTLS_X509VERIFY_FATAL_ERROR) {
       failf(data, "Cert handshake failed. %s. UnityTls error code: %i", 
         unitytls->unitytls_x509verify_result_to_string(verifyresult), err.code);
@@ -541,7 +542,7 @@ static CURLcode unitytls_connect_step2(struct Curl_easy* data, struct ssl_connec
       for (uint32_t mask = 1; mask >= 0x80000000; mask <<= 1) {
         if(verifyresult & mask)
           failf(data, "Cert verify failed. %s. UnityTls error code: %i",
-                unitytls->unitytls_x509verify_result_to_string(verifyresult), err.code);
+                unitytls->unitytls_x509verify_result_to_string(mask), err.code);
       }
       if(verifyresult & UNITYTLS_X509VERIFY_FLAG_REVOKED) {
         return CURLE_SSL_CACERT_BADFILE;

--- a/lib/vtls/unitytls.c
+++ b/lib/vtls/unitytls.c
@@ -532,14 +532,14 @@ static CURLcode unitytls_connect_step2(struct Curl_easy* data, struct ssl_connec
   }
 
   if(verifyresult != UNITYTLS_X509VERIFY_SUCCESS) {
-    failf(data, "Cert handshake failed. UnityTls error code: %i (verify result: %X)", err.code, verifyresult);
     if(verifyresult == UNITYTLS_X509VERIFY_FATAL_ERROR) {
       failf(data, "Cert handshake failed. %s. UnityTls error code: %i", 
         unitytls->unitytls_x509verify_result_to_string(verifyresult), err.code);
       return CURLE_SSL_CONNECT_ERROR;
     }
     else {
-      for (uint32_t mask = 1; mask >= 0x80000000; mask <<= 1) {
+      for (int i = 0; i < 32; ++i) {
+        const uint32_t mask = 1 << i;
         if(verifyresult & mask)
           failf(data, "Cert verify failed. %s. UnityTls error code: %i",
                 unitytls->unitytls_x509verify_result_to_string(mask), err.code);

--- a/lib/vtls/unitytls.c
+++ b/lib/vtls/unitytls.c
@@ -532,7 +532,7 @@ static CURLcode unitytls_connect_step2(struct Curl_easy* data, struct ssl_connec
   }
 
   if(verifyresult != UNITYTLS_X509VERIFY_SUCCESS) {
-    failf(data, "Cert handshake failed. UnityTls error code: %i (verify result: %X)", err.code, verifyresult)
+    failf(data, "Cert handshake failed. UnityTls error code: %i (verify result: %X)", err.code, verifyresult);
     if(verifyresult == UNITYTLS_X509VERIFY_FATAL_ERROR) {
       failf(data, "Cert handshake failed. %s. UnityTls error code: %i", 
         unitytls->unitytls_x509verify_result_to_string(verifyresult), err.code);

--- a/lib/vtls/unitytls_interface.h
+++ b/lib/vtls/unitytls_interface.h
@@ -291,7 +291,7 @@ typedef struct unitytls_interface_struct
 
     unitytls_x509verify_default_ca_t unitytls_x509verify_default_ca;
     unitytls_x509verify_explicit_ca_t unitytls_x509verify_explicit_ca;
-    unitytls_x509verify_result_to_string_t unitytls_x509verify_result;
+    unitytls_x509verify_result_to_string_t unitytls_x509verify_result_to_string;
 
     unitytls_tlsctx_create_server_t unitytls_tlsctx_create_server;
     unitytls_tlsctx_create_client_t unitytls_tlsctx_create_client;

--- a/lib/vtls/unitytls_interface.h
+++ b/lib/vtls/unitytls_interface.h
@@ -291,14 +291,12 @@ typedef struct unitytls_interface_struct
 
     unitytls_x509verify_default_ca_t unitytls_x509verify_default_ca;
     unitytls_x509verify_explicit_ca_t unitytls_x509verify_explicit_ca;
-    unitytls_x509verify_result_to_string_t unitytls_x509verify_result_to_string;
 
     unitytls_tlsctx_create_server_t unitytls_tlsctx_create_server;
     unitytls_tlsctx_create_client_t unitytls_tlsctx_create_client;
     unitytls_tlsctx_server_require_client_authentication_t unitytls_tlsctx_server_require_client_authentication;
     unitytls_tlsctx_set_certificate_callback_t unitytls_tlsctx_set_certificate_callback;
     unitytls_tlsctx_set_trace_callback_t unitytls_tlsctx_set_trace_callback;
-    unitytls_tlsctx_set_trace_level_callback_t unitytls_tlsctx_set_trace_level_callback;
     unitytls_tlsctx_set_x509verify_callback_t unitytls_tlsctx_set_x509verify_callback;
     unitytls_tlsctx_set_supported_ciphersuites_t unitytls_tlsctx_set_supported_ciphersuites;
     unitytls_tlsctx_get_ciphersuite_t unitytls_tlsctx_get_ciphersuite;
@@ -310,6 +308,9 @@ typedef struct unitytls_interface_struct
     unitytls_tlsctx_free_t unitytls_tlsctx_free;
 
     unitytls_random_generate_bytes_t unitytls_random_generate_bytes;
+
+    unitytls_x509verify_result_to_string_t unitytls_x509verify_result_to_string;
+    unitytls_tlsctx_set_trace_level_t unitytls_tlsctx_set_trace_level;
 } unitytls_interface_struct;
 
 

--- a/lib/vtls/unitytls_interface.h
+++ b/lib/vtls/unitytls_interface.h
@@ -247,7 +247,7 @@ typedef unitytls_tlsctx*            (*unitytls_tlsctx_create_server_t)(unitytls_
 typedef unitytls_tlsctx*            (*unitytls_tlsctx_create_client_t)(unitytls_tlsctx_protocolrange supportedProtocols, unitytls_tlsctx_callbacks callbacks, const char* cn, size_t cnLen, unitytls_errorstate* errorState);
 typedef void                        (*unitytls_tlsctx_server_require_client_authentication_t)(unitytls_tlsctx* ctx, unitytls_x509list_ref clientAuthCAList, unitytls_errorstate* errorState);
 typedef void                        (*unitytls_tlsctx_set_certificate_callback_t)(unitytls_tlsctx* ctx, unitytls_tlsctx_certificate_callback cb, void* userData, unitytls_errorstate* errorState);
-typedef void                        (*unitytls_tlsctx_set_trace_t)(unitytls_tlsctx* ctx, unitytls_tlsctx_trace_callback cb, void* userData, unitytls_errorstate* errorState);
+typedef void                        (*unitytls_tlsctx_set_trace_callback_t)(unitytls_tlsctx* ctx, unitytls_tlsctx_trace_callback cb, void* userData, unitytls_errorstate* errorState);
 typedef void                        (*unitytls_tlsctx_set_trace_level_t)(unitytls_tlsctx* ctx, unitytls_log_level level);
 typedef void                        (*unitytls_tlsctx_set_x509verify_callback_t)(unitytls_tlsctx* ctx, unitytls_tlsctx_x509verify_callback cb, void* userData, unitytls_errorstate* errorState);
 typedef void                        (*unitytls_tlsctx_set_supported_ciphersuites_t)(unitytls_tlsctx* ctx, unitytls_ciphersuite* supportedCiphersuites, size_t supportedCiphersuitesLen, unitytls_errorstate* errorState);

--- a/lib/vtls/unitytls_interface.h
+++ b/lib/vtls/unitytls_interface.h
@@ -248,7 +248,7 @@ typedef unitytls_tlsctx*            (*unitytls_tlsctx_create_client_t)(unitytls_
 typedef void                        (*unitytls_tlsctx_server_require_client_authentication_t)(unitytls_tlsctx* ctx, unitytls_x509list_ref clientAuthCAList, unitytls_errorstate* errorState);
 typedef void                        (*unitytls_tlsctx_set_certificate_callback_t)(unitytls_tlsctx* ctx, unitytls_tlsctx_certificate_callback cb, void* userData, unitytls_errorstate* errorState);
 typedef void                        (*unitytls_tlsctx_set_trace_callback_t)(unitytls_tlsctx* ctx, unitytls_tlsctx_trace_callback cb, void* userData, unitytls_errorstate* errorState);
-typedef void                        (*unitytls_tlsctx_set_trace_level_callback_t)(unitytls_tlsctx* ctx, unitytls_log_level level);
+typedef void                        (*unitytls_tlsctx_set_trace_level_t)(unitytls_tlsctx* ctx, unitytls_log_level level);
 
 typedef void                        (*unitytls_tlsctx_set_x509verify_callback_t)(unitytls_tlsctx* ctx, unitytls_tlsctx_x509verify_callback cb, void* userData, unitytls_errorstate* errorState);
 typedef void                        (*unitytls_tlsctx_set_supported_ciphersuites_t)(unitytls_tlsctx* ctx, unitytls_ciphersuite* supportedCiphersuites, size_t supportedCiphersuitesLen, unitytls_errorstate* errorState);

--- a/lib/vtls/unitytls_interface.h
+++ b/lib/vtls/unitytls_interface.h
@@ -290,14 +290,12 @@ typedef struct unitytls_interface_struct
 
     unitytls_x509verify_default_ca_t unitytls_x509verify_default_ca;
     unitytls_x509verify_explicit_ca_t unitytls_x509verify_explicit_ca;
-    unitytls_x509verify_result_to_string_t unitytls_x509verify_result_to_string;
 
     unitytls_tlsctx_create_server_t unitytls_tlsctx_create_server;
     unitytls_tlsctx_create_client_t unitytls_tlsctx_create_client;
     unitytls_tlsctx_server_require_client_authentication_t unitytls_tlsctx_server_require_client_authentication;
     unitytls_tlsctx_set_certificate_callback_t unitytls_tlsctx_set_certificate_callback;
     unitytls_tlsctx_set_trace_callback_t unitytls_tlsctx_set_trace_callback;
-    unitytls_tlsctx_set_trace_level_t unitytls_tlsctx_set_trace_level;
     unitytls_tlsctx_set_x509verify_callback_t unitytls_tlsctx_set_x509verify_callback;
     unitytls_tlsctx_set_supported_ciphersuites_t unitytls_tlsctx_set_supported_ciphersuites;
     unitytls_tlsctx_get_ciphersuite_t unitytls_tlsctx_get_ciphersuite;

--- a/lib/vtls/unitytls_interface.h
+++ b/lib/vtls/unitytls_interface.h
@@ -247,7 +247,7 @@ typedef unitytls_tlsctx*            (*unitytls_tlsctx_create_server_t)(unitytls_
 typedef unitytls_tlsctx*            (*unitytls_tlsctx_create_client_t)(unitytls_tlsctx_protocolrange supportedProtocols, unitytls_tlsctx_callbacks callbacks, const char* cn, size_t cnLen, unitytls_errorstate* errorState);
 typedef void                        (*unitytls_tlsctx_server_require_client_authentication_t)(unitytls_tlsctx* ctx, unitytls_x509list_ref clientAuthCAList, unitytls_errorstate* errorState);
 typedef void                        (*unitytls_tlsctx_set_certificate_callback_t)(unitytls_tlsctx* ctx, unitytls_tlsctx_certificate_callback cb, void* userData, unitytls_errorstate* errorState);
-typedef void                        (*unitytls_tlsctx_set_trace_callback_t)(unitytls_tlsctx* ctx, unitytls_tlsctx_trace_callback cb, void* userData, unitytls_errorstate* errorState);
+typedef void                        (*unitytls_tlsctx_set_trace_t)(unitytls_tlsctx* ctx, unitytls_tlsctx_trace_callback cb, void* userData, unitytls_errorstate* errorState);
 typedef void                        (*unitytls_tlsctx_set_trace_level_t)(unitytls_tlsctx* ctx, unitytls_log_level level);
 typedef void                        (*unitytls_tlsctx_set_x509verify_callback_t)(unitytls_tlsctx* ctx, unitytls_tlsctx_x509verify_callback cb, void* userData, unitytls_errorstate* errorState);
 typedef void                        (*unitytls_tlsctx_set_supported_ciphersuites_t)(unitytls_tlsctx* ctx, unitytls_ciphersuite* supportedCiphersuites, size_t supportedCiphersuitesLen, unitytls_errorstate* errorState);
@@ -297,7 +297,7 @@ typedef struct unitytls_interface_struct
     unitytls_tlsctx_server_require_client_authentication_t unitytls_tlsctx_server_require_client_authentication;
     unitytls_tlsctx_set_certificate_callback_t unitytls_tlsctx_set_certificate_callback;
     unitytls_tlsctx_set_trace_callback_t unitytls_tlsctx_set_trace_callback;
-    unitytls_tlsctx_set_trace_level_callback_t unitytls_tlsctx_set_trace_level_callback;
+    unitytls_tlsctx_set_trace_level_t unitytls_tlsctx_set_trace_level;
     unitytls_tlsctx_set_x509verify_callback_t unitytls_tlsctx_set_x509verify_callback;
     unitytls_tlsctx_set_supported_ciphersuites_t unitytls_tlsctx_set_supported_ciphersuites;
     unitytls_tlsctx_get_ciphersuite_t unitytls_tlsctx_get_ciphersuite;


### PR DESCRIPTION
Moved `unitytls_x509verify_result_to_string` and `unitytls_tlsctx_set_trace_level` in the UnityTLS struct interface to match the declaration in the UnityTLS repo.