### PR TITLE
Add support for TLS 1.3

### DIFF
--- a/lib/vtls/unitytls.c
+++ b/lib/vtls/unitytls.c
@@ -393,16 +393,15 @@ static CURLcode unitytls_connect_step1(struct Curl_cfilter *cf, struct Curl_easy
 
   unitytls_tlsctx_callbacks callbacks = { unitytls_on_read, unitytls_on_write, cf };
 
-  /* unitytls only supports TLS 1.0-1.2 */
+  /* unitytls only supports TLS 1.2-1.3 */
   switch (conn_config->version)
   {
     case CURL_SSLVERSION_DEFAULT:
-    case CURL_SSLVERSION_TLSv1_0:
-    case CURL_SSLVERSION_TLSv1_1:
     case CURL_SSLVERSION_TLSv1_2:
+    case CURL_SSLVERSION_TLSv1_3:
       break;
     default:
-      failf(data, "unitytls only supports TLS 1.0-1.2");
+      failf(data, "unitytls only supports TLS 1.2-1.3");
       return CURLE_SSL_CONNECT_ERROR;
   }
 
@@ -456,14 +455,11 @@ static CURLcode unitytls_connect_step1(struct Curl_cfilter *cf, struct Curl_easy
     case CURL_SSLVERSION_DEFAULT:
       protocol_range = unitytls->UNITYTLS_TLSCTX_PROTOCOLRANGE_DEFAULT;
       break;
-    case CURL_SSLVERSION_TLSv1_0:
-      protocol_range.max = protocol_range.min = UNITYTLS_PROTOCOL_TLS_1_0;
-      break;
-    case CURL_SSLVERSION_TLSv1_1:
-      protocol_range.max = protocol_range.min = UNITYTLS_PROTOCOL_TLS_1_1;
-      break;
     case CURL_SSLVERSION_TLSv1_2:
       protocol_range.max = protocol_range.min = UNITYTLS_PROTOCOL_TLS_1_2;
+      break;
+    case CURL_SSLVERSION_TLSv1_3:
+      protocol_range.max = protocol_range.min = UNITYTLS_PROTOCOL_TLS_1_3;
       break;
     default:
       failf(data, "Unrecognized/unsupported parameter passed via CURLOPT_SSLVERSION");

--- a/lib/vtls/unitytls_interface.h
+++ b/lib/vtls/unitytls_interface.h
@@ -179,6 +179,7 @@ typedef enum
     UNITYTLS_PROTOCOL_TLS_1_0,
     UNITYTLS_PROTOCOL_TLS_1_1,
     UNITYTLS_PROTOCOL_TLS_1_2,
+    UNITYTLS_PROTOCOL_TLS_1_3,
 
     UNITYTLS_PROTOCOL_INVALID,
 } unitytls_protocol_t;
@@ -189,7 +190,6 @@ typedef struct
     unitytls_protocol min;
     unitytls_protocol max;
 } unitytls_tlsctx_protocolrange;
-extern const unitytls_tlsctx_protocolrange UNITYTLS_TLSCTX_PROTOCOLRANGE_DEFAULT;
 
 typedef enum
 {


### PR DESCRIPTION
This PR adds support for TLS 1.3 to our UnityTLS VTLS wrapper.

Note that these changes are not actually required to get TLS 1.3 working with `UnityWebRequest`. Our wrapper defers to UnityTLS to get the default protocol versions (through `UNITYTLS_TLSCTX_PROTOCOLRANGE_DEFAULT`) so if we update UnityTLS with TLS 1.3 support it will automatically be picked up here. The changes in this PR are only required if we want to explicitly tell Curl to use TLS 1.3, although I don't know if any of the ways to do so are actually exposed to users. Still, it's a good thing to be thorough and update Curl anyway.

The diff in `unitytls.c` looks huge because I normalized the line endings (for some reason the file was committed with CRLF but the rest of Curl uses LF only). Here are the changes to that file without the whitespace noise:

```diff
@@ -393,16 +393,15 @@ static CURLcode unitytls_connect_step1(struct Curl_cfilter *cf, struct Curl_easy

   unitytls_tlsctx_callbacks callbacks = { unitytls_on_read, unitytls_on_write, cf };

-  /* unitytls only supports TLS 1.0-1.2 */
+  /* unitytls only supports TLS 1.2-1.3 */
   switch (conn_config->version)
   {
     case CURL_SSLVERSION_DEFAULT:
-    case CURL_SSLVERSION_TLSv1_0:
-    case CURL_SSLVERSION_TLSv1_1:
     case CURL_SSLVERSION_TLSv1_2:
+    case CURL_SSLVERSION_TLSv1_3:
       break;
     default:
-      failf(data, "unitytls only supports TLS 1.0-1.2");
+      failf(data, "unitytls only supports TLS 1.2-1.3");
       return CURLE_SSL_CONNECT_ERROR;
   }

@@ -456,15 +455,12 @@ static CURLcode unitytls_connect_step1(struct Curl_cfilter *cf, struct Curl_easy
     case CURL_SSLVERSION_DEFAULT:
       protocol_range = unitytls->UNITYTLS_TLSCTX_PROTOCOLRANGE_DEFAULT;
       break;
-    case CURL_SSLVERSION_TLSv1_0:
-      protocol_range.max = protocol_range.min = UNITYTLS_PROTOCOL_TLS_1_0;
-      break;
-    case CURL_SSLVERSION_TLSv1_1:
-      protocol_range.max = protocol_range.min = UNITYTLS_PROTOCOL_TLS_1_1;
-      break;
     case CURL_SSLVERSION_TLSv1_2:
       protocol_range.max = protocol_range.min = UNITYTLS_PROTOCOL_TLS_1_2;
       break;
+    case CURL_SSLVERSION_TLSv1_3:
+      protocol_range.max = protocol_range.min = UNITYTLS_PROTOCOL_TLS_1_3;
+      break;
     default:
       failf(data, "Unrecognized/unsupported parameter passed via CURLOPT_SSLVERSION");
       return CURLE_SSL_CONNECT_ERROR;
```