### PR TITLE
Guard SSPI teardown calls against NULL Curl_pSecFn

### DIFF
--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -642,8 +642,7 @@ void Curl_auth_digest_cleanup(struct digestdata *digest)
   /* Reset any variables */
   digest->input_token_len = 0;
 
-  /* Delete security context; Curl_pSecFn is NULL after
-     curl_global_cleanup(), the OS then reclaims handles at process exit */
+  /* Delete security context */
   if(digest->http_context) {
     if(Curl_pSecFn)
       Curl_pSecFn->DeleteSecurityContext(digest->http_context);

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -642,9 +642,11 @@ void Curl_auth_digest_cleanup(struct digestdata *digest)
   /* Reset any variables */
   digest->input_token_len = 0;
 
-  /* Delete security context */
+  /* Delete security context; Curl_pSecFn is NULL after
+     curl_global_cleanup(), the OS then reclaims handles at process exit */
   if(digest->http_context) {
-    Curl_pSecFn->DeleteSecurityContext(digest->http_context);
+    if(Curl_pSecFn)
+      Curl_pSecFn->DeleteSecurityContext(digest->http_context);
     curlx_safefree(digest->http_context);
   }
 

--- a/lib/vauth/krb5_sspi.c
+++ b/lib/vauth/krb5_sspi.c
@@ -425,8 +425,7 @@ out:
  */
 void Curl_auth_cleanup_gssapi(struct kerberos5data *krb5)
 {
-  /* Free our security context; Curl_pSecFn is NULL after
-     curl_global_cleanup(), the OS then reclaims handles at process exit */
+  /* Free our security context */
   if(krb5->context) {
     if(Curl_pSecFn)
       Curl_pSecFn->DeleteSecurityContext(krb5->context);

--- a/lib/vauth/krb5_sspi.c
+++ b/lib/vauth/krb5_sspi.c
@@ -425,16 +425,19 @@ out:
  */
 void Curl_auth_cleanup_gssapi(struct kerberos5data *krb5)
 {
-  /* Free our security context */
+  /* Free our security context; Curl_pSecFn is NULL after
+     curl_global_cleanup(), the OS then reclaims handles at process exit */
   if(krb5->context) {
-    Curl_pSecFn->DeleteSecurityContext(krb5->context);
+    if(Curl_pSecFn)
+      Curl_pSecFn->DeleteSecurityContext(krb5->context);
     curlx_free(krb5->context);
     krb5->context = NULL;
   }
 
   /* Free our credentials handle */
   if(krb5->credentials) {
-    Curl_pSecFn->FreeCredentialsHandle(krb5->credentials);
+    if(Curl_pSecFn)
+      Curl_pSecFn->FreeCredentialsHandle(krb5->credentials);
     curlx_free(krb5->credentials);
     krb5->credentials = NULL;
   }

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -322,16 +322,19 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
  */
 void Curl_auth_cleanup_ntlm(struct ntlmdata *ntlm)
 {
-  /* Free our security context */
+  /* Free our security context; Curl_pSecFn is NULL after
+     curl_global_cleanup(), the OS then reclaims handles at process exit */
   if(ntlm->context) {
-    Curl_pSecFn->DeleteSecurityContext(ntlm->context);
+    if(Curl_pSecFn)
+      Curl_pSecFn->DeleteSecurityContext(ntlm->context);
     curlx_free(ntlm->context);
     ntlm->context = NULL;
   }
 
   /* Free our credentials handle */
   if(ntlm->credentials) {
-    Curl_pSecFn->FreeCredentialsHandle(ntlm->credentials);
+    if(Curl_pSecFn)
+      Curl_pSecFn->FreeCredentialsHandle(ntlm->credentials);
     curlx_free(ntlm->credentials);
     ntlm->credentials = NULL;
   }

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -322,8 +322,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
  */
 void Curl_auth_cleanup_ntlm(struct ntlmdata *ntlm)
 {
-  /* Free our security context; Curl_pSecFn is NULL after
-     curl_global_cleanup(), the OS then reclaims handles at process exit */
+  /* Free our security context */
   if(ntlm->context) {
     if(Curl_pSecFn)
       Curl_pSecFn->DeleteSecurityContext(ntlm->context);

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -310,8 +310,7 @@ CURLcode Curl_auth_create_spnego_message(struct negotiatedata *nego,
  */
 void Curl_auth_cleanup_spnego(struct negotiatedata *nego)
 {
-  /* Free our security context; Curl_pSecFn is NULL after
-     curl_global_cleanup(), the OS then reclaims handles at process exit */
+  /* Free our security context */
   if(nego->context) {
     if(Curl_pSecFn)
       Curl_pSecFn->DeleteSecurityContext(nego->context);

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -310,16 +310,19 @@ CURLcode Curl_auth_create_spnego_message(struct negotiatedata *nego,
  */
 void Curl_auth_cleanup_spnego(struct negotiatedata *nego)
 {
-  /* Free our security context */
+  /* Free our security context; Curl_pSecFn is NULL after
+     curl_global_cleanup(), the OS then reclaims handles at process exit */
   if(nego->context) {
-    Curl_pSecFn->DeleteSecurityContext(nego->context);
+    if(Curl_pSecFn)
+      Curl_pSecFn->DeleteSecurityContext(nego->context);
     curlx_free(nego->context);
     nego->context = NULL;
   }
 
   /* Free our credentials handle */
   if(nego->credentials) {
-    Curl_pSecFn->FreeCredentialsHandle(nego->credentials);
+    if(Curl_pSecFn)
+      Curl_pSecFn->FreeCredentialsHandle(nego->credentials);
     curlx_free(nego->credentials);
     nego->credentials = NULL;
   }


### PR DESCRIPTION
## Problem

The vauth cleanup paths call through the SSPI dispatch table unconditionally. `Curl_sspi_global_cleanup()` sets `Curl_pSecFn` to NULL (it no longer unloads secur32, it only clears the pointer), so if auth state is ever destroyed after global cleanup has run, for example a multi handle torn down late by an embedder, the connection destructors dereference the NULL table and crash:

```
Curl_auth_cleanup_spnego   (vauth/spnego_sspi.c:315)
<- nego_conn_dtor <- Curl_conn_free <- Curl_cpool_destroy <- curl_multi_cleanup
```

Destroying handles after `curl_global_cleanup()` is outside the documented API contract, but this library is embedded as a static lib into several products with independently wired shutdown paths, and nothing enforces the ordering at build time. Failing soft here turns that class of mistake into a no-op instead of a crash.

## Fix

Guard the SSPI calls in the four vauth cleanup paths (spnego, ntlm, krb5, digest) with a `Curl_pSecFn` NULL check. Our own allocations are still freed; only the calls into secur32 are skipped, and the OS reclaims those handles at process exit.

## Testing

`scripts/checksrc.pl` passes on the touched files. Runtime validation happens downstream once the submodule and artifacts are updated.
